### PR TITLE
fix(docs): move doc targets to `docs` root

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -3347,7 +3347,7 @@
       }
     },
     "//:extensions.bzl%graalvm": {
-      "bzlTransitiveDigest": "tRgHoVzahIC6lb9CbdUTElSAl7FhYccLMZO33cXLpms=",
+      "bzlTransitiveDigest": "fqExuMHwaK7JMR6OBbQdQiR/i1/6ortbaTc8NTldIXw=",
       "envVariables": {},
       "generatedRepoSpecs": {
         "graalvm": {

--- a/docs/api/BUILD.bazel
+++ b/docs/api/BUILD.bazel
@@ -1,11 +1,26 @@
 "Aliases to documentation targets for the package API."
 
-alias(
-    name = "defs",
-    actual = "//graalvm:defs_doc",
+load(
+    "@io_bazel_stardoc//stardoc:stardoc.bzl",
+    "stardoc",
 )
 
-alias(
+stardoc(
+    name = "defs",
+    out = "defs.md",
+    input = "//graalvm:defs.bzl",
+    deps = [
+        "//graalvm/nativeimage:rules",
+        "//internal:tooling",
+    ],
+)
+
+stardoc(
     name = "repositories",
-    actual = "//graalvm:repositories_doc",
+    out = "repositories.md",
+    input = "//graalvm:repositories.bzl",
+    deps = [
+        "//internal:bindist",
+        "//internal:tooling",
+    ],
 )

--- a/docs/api/defs.md
+++ b/docs/api/defs.md
@@ -7,25 +7,25 @@ Target rule definitions, intended for use by rule users.
 ## native_image
 
 <pre>
-native_image(<a href="#native_image-name">name</a>, <a href="#native_image-c_compiler_option">c_compiler_option</a>, <a href="#native_image-data">data</a>, <a href="#native_image-deps">deps</a>, <a href="#native_image-extra_args">extra_args</a>, <a href="#native_image-graalvm">graalvm</a>, <a href="#native_image-include_resources">include_resources</a>,
+native_image(<a href="#native_image-name">name</a>, <a href="#native_image-c_compiler_option">c_compiler_option</a>, <a href="#native_image-data">data</a>, <a href="#native_image-deps">deps</a>, <a href="#native_image-extra_args">extra_args</a>, <a href="#native_image-include_resources">include_resources</a>,
              <a href="#native_image-initialize_at_build_time">initialize_at_build_time</a>, <a href="#native_image-initialize_at_run_time">initialize_at_run_time</a>, <a href="#native_image-jni_configuration">jni_configuration</a>, <a href="#native_image-main_class">main_class</a>,
-             <a href="#native_image-native_features">native_features</a>, <a href="#native_image-reflection_configuration">reflection_configuration</a>)
+             <a href="#native_image-native_features">native_features</a>, <a href="#native_image-native_image">native_image</a>, <a href="#native_image-reflection_configuration">reflection_configuration</a>)
 </pre>
 
 **ATTRIBUTES**
 
-| Name                                                                       | Description                    | Type                                                                | Mandatory | Default                                  |
-| :------------------------------------------------------------------------- | :----------------------------- | :------------------------------------------------------------------ | :-------- | :--------------------------------------- |
-| <a id="native_image-name"></a>name                                         | A unique name for this target. | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required  |                                          |
-| <a id="native_image-c_compiler_option"></a>c_compiler_option               | -                              | List of strings                                                     | optional  | <code>[]</code>                          |
-| <a id="native_image-data"></a>data                                         | -                              | <a href="https://bazel.build/concepts/labels">List of labels</a>    | optional  | <code>[]</code>                          |
-| <a id="native_image-deps"></a>deps                                         | -                              | <a href="https://bazel.build/concepts/labels">List of labels</a>    | optional  | <code>[]</code>                          |
-| <a id="native_image-extra_args"></a>extra_args                             | -                              | List of strings                                                     | optional  | <code>[]</code>                          |
-| <a id="native_image-graalvm"></a>graalvm                                   | -                              | <a href="https://bazel.build/concepts/labels">Label</a>             | optional  | <code>@graalvm//:bin/native-image</code> |
-| <a id="native_image-include_resources"></a>include_resources               | -                              | String                                                              | optional  | <code>""</code>                          |
-| <a id="native_image-initialize_at_build_time"></a>initialize_at_build_time | -                              | List of strings                                                     | optional  | <code>[]</code>                          |
-| <a id="native_image-initialize_at_run_time"></a>initialize_at_run_time     | -                              | List of strings                                                     | optional  | <code>[]</code>                          |
-| <a id="native_image-jni_configuration"></a>jni_configuration               | -                              | <a href="https://bazel.build/concepts/labels">Label</a>             | optional  | <code>None</code>                        |
-| <a id="native_image-main_class"></a>main_class                             | -                              | String                                                              | optional  | <code>""</code>                          |
-| <a id="native_image-native_features"></a>native_features                   | -                              | List of strings                                                     | optional  | <code>[]</code>                          |
-| <a id="native_image-reflection_configuration"></a>reflection_configuration | -                              | <a href="https://bazel.build/concepts/labels">Label</a>             | optional  | <code>None</code>                        |
+| Name                                                                       | Description                    | Type                                                                | Mandatory | Default                              |
+| :------------------------------------------------------------------------- | :----------------------------- | :------------------------------------------------------------------ | :-------- | :----------------------------------- |
+| <a id="native_image-name"></a>name                                         | A unique name for this target. | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required  |                                      |
+| <a id="native_image-c_compiler_option"></a>c_compiler_option               | -                              | List of strings                                                     | optional  | <code>[]</code>                      |
+| <a id="native_image-data"></a>data                                         | -                              | <a href="https://bazel.build/concepts/labels">List of labels</a>    | optional  | <code>[]</code>                      |
+| <a id="native_image-deps"></a>deps                                         | -                              | <a href="https://bazel.build/concepts/labels">List of labels</a>    | optional  | <code>[]</code>                      |
+| <a id="native_image-extra_args"></a>extra_args                             | -                              | List of strings                                                     | optional  | <code>[]</code>                      |
+| <a id="native_image-include_resources"></a>include_resources               | -                              | String                                                              | optional  | <code>""</code>                      |
+| <a id="native_image-initialize_at_build_time"></a>initialize_at_build_time | -                              | List of strings                                                     | optional  | <code>[]</code>                      |
+| <a id="native_image-initialize_at_run_time"></a>initialize_at_run_time     | -                              | List of strings                                                     | optional  | <code>[]</code>                      |
+| <a id="native_image-jni_configuration"></a>jni_configuration               | -                              | <a href="https://bazel.build/concepts/labels">Label</a>             | optional  | <code>None</code>                    |
+| <a id="native_image-main_class"></a>main_class                             | -                              | String                                                              | optional  | <code>""</code>                      |
+| <a id="native_image-native_features"></a>native_features                   | -                              | List of strings                                                     | optional  | <code>[]</code>                      |
+| <a id="native_image-native_image"></a>native_image                         | -                              | <a href="https://bazel.build/concepts/labels">Label</a>             | optional  | <code>@graalvm//:native-image</code> |
+| <a id="native_image-reflection_configuration"></a>reflection_configuration | -                              | <a href="https://bazel.build/concepts/labels">Label</a>             | optional  | <code>None</code>                    |

--- a/graalvm/BUILD.bazel
+++ b/graalvm/BUILD.bazel
@@ -1,11 +1,11 @@
+"Provides `bzl_library` definitions for GraalVM repository and target rules."
+
 load(
     "@bazel_skylib//:bzl_library.bzl",
     "bzl_library",
 )
-load(
-    "@io_bazel_stardoc//stardoc:stardoc.bzl",
-    "stardoc",
-)
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "defs.bzl",
@@ -28,28 +28,6 @@ bzl_library(
     srcs = [
         "repositories.bzl",
     ],
-    deps = [
-        "//internal:bindist",
-        "//internal:tooling",
-    ],
-)
-
-stardoc(
-    name = "defs_doc",
-    out = "defs.md",
-    input = "defs.bzl",
-    visibility = ["//docs:__subpackages__"],
-    deps = [
-        "//graalvm/nativeimage:rules",
-        "//internal:tooling",
-    ],
-)
-
-stardoc(
-    name = "repositories_doc",
-    out = "repositories.md",
-    input = "repositories.bzl",
-    visibility = ["//docs:__subpackages__"],
     deps = [
         "//internal:bindist",
         "//internal:tooling",

--- a/graalvm/nativeimage/BUILD.bazel
+++ b/graalvm/nativeimage/BUILD.bazel
@@ -1,7 +1,11 @@
+"Rules for generating binaries with the GraalVM `native-image` tool."
+
 load(
     "@bazel_skylib//:bzl_library.bzl",
     "bzl_library",
 )
+
+package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "rules.bzl",
@@ -10,6 +14,5 @@ exports_files([
 bzl_library(
     name = "rules",
     srcs = ["rules.bzl"],
-    visibility = ["//graalvm:__subpackages__"],
     deps = ["//internal:tooling"],
 )

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,7 +1,14 @@
+"Bazel library targets for GraalVM rule internals."
+
 load(
     "@bazel_skylib//:bzl_library.bzl",
     "bzl_library",
 )
+
+package(default_visibility = [
+    "//docs:__subpackages__",
+    "//graalvm:__subpackages__",
+])
 
 exports_files([
     "config.bzl",
@@ -14,7 +21,6 @@ bzl_library(
     srcs = [
         "@bazel_tools//tools:bzl_srcs",
     ],
-    visibility = ["//graalvm:__subpackages__"],
 )
 
 bzl_library(
@@ -32,7 +38,6 @@ bzl_library(
 bzl_library(
     name = "bindist",
     srcs = ["graalvm_bindist.bzl"],
-    visibility = ["//graalvm:__subpackages__"],
     deps = [
         ":java_toolchains",
         ":tooling",
@@ -42,7 +47,6 @@ bzl_library(
 bzl_library(
     name = "maven",
     srcs = ["maven.bzl"],
-    visibility = ["//graalvm:__subpackages__"],
     deps = [
         ":config",
         ":tooling",


### PR DESCRIPTION
## Summary

Moves docs targets to the `docs` root, so they don't surface downstream for Bzlmod users.

## Changelog

- fix: move doc targets, recommended in bazelbuild/bazel-central-registry#836
- chore: update module lock
- chore: public visibility for `bzl_library` targets (downstream docs)

(thank you @fmeum!)