### PR TITLE
fix: bcr tarball endpoint

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_graalvm-{VERSION}.zip"
 }

--- a/.github/workflows/on.release.yml
+++ b/.github/workflows/on.release.yml
@@ -11,4 +11,4 @@ jobs:
     name: "Release: BCR"
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v2
     with:
-      release_files: rules_graalvm-*.tar.gz
+      release_files: rules_graalvm-*.zip


### PR DESCRIPTION
## Summary

Use the artifact download URL for a given rules release, instead of the tag archive. Referenced in bazelbuild/bazel-central-registry#869. Thanks @fmeum!

## Changelog

- fix: set the BCR download endpoint for `rules_graalvm` to the release artifact, which is stable