### PR TITLE
chore: issue fix release → `0.10.1`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 
 module(
     name = "rules_graalvm",
-    version = "0.10.0",
+    version = "0.10.1",
 )
 
 JAVA_VERSION = "20"

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 1,
-  "moduleFileHash": "fe507dc0e7222190bf7f386e759bf749e0c87f86f84fbc11f3703bd8c1262cc3",
+  "moduleFileHash": "91f589b49b289d8b52a5e1683c0884879c0496cad407e79a327b6fd8608ebba5",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -18,7 +18,7 @@
   "moduleDepGraph": {
     "<root>": {
       "name": "rules_graalvm",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "key": "<root>",
       "repoName": "rules_graalvm",
       "executionPlatformsToRegister": [],

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ---
 
-> Latest release: `0.10.0`
+> Latest release: `0.10.1`
 
 > **Important**
 > Currently in beta. Feedback welcome but will probably break your build.
@@ -37,10 +37,10 @@ Use [GraalVM](https://graalvm.org) from [Bazel](https://bazel.build), with suppo
 ```starlark
 http_archive(
     name = "rules_graalvm",
-    sha256 = "157efdd3a6ac12b85838ae81042f2fdcf60d70ba5fb279585ca8f27cf7f1a94d",
-    strip_prefix = "rules_graalvm-0.10.0",
+    sha256 = "ca6fa64992139a3fd04fd878857319d4b865c80624e6a73967d340be4f64cb52",
+    strip_prefix = "rules_graalvm-0.10.1",
     urls = [
-        "https://github.com/sgammon/rules_graalvm/releases/download/v0.10.0/rules_graalvm-0.10.0.zip",
+        "https://github.com/sgammon/rules_graalvm/releases/download/v0.10.1/rules_graalvm-0.10.1.zip",
     ],
 )
 ```
@@ -77,16 +77,16 @@ register_graalvm_toolchains()
 > To use Bzlmod with `rules_graalvm`, you will need the `archive_override` below (until we go live on BCR).
 
 ```starlark
-bazel_dep(name = "rules_graalvm", version = "0.10.0")
+bazel_dep(name = "rules_graalvm", version = "0.10.1")
 ```
 
 ```starlark
 # Until we ship to BCR:
 archive_override(
     module_name = "rules_graalvm",
-    urls = ["https://github.com/sgammon/rules_graalvm/releases/download/v0.10.0/rules_graalvm-0.10.0.zip"],
-    strip_prefix = "rules_graalvm-0.10.0",
-    integrity = "sha256-FX7906asErhYOK6BBC8v3PYNcLpfsnlYXKjyfPfxqU0=",
+    urls = ["https://github.com/sgammon/rules_graalvm/releases/download/v0.10.1/rules_graalvm-0.10.1.zip"],
+    strip_prefix = "rules_graalvm-0.10.1",
+    integrity = "sha256-ym+mSZITmj/QT9h4hXMZ1LhlyAYk5qc5Z9NAvk9ky1I=",
 )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 
 ---
 
-> Latest release: `0.10.0`
+> Latest release: `0.10.1`
 
 > **Important**
 > Currently in beta. Feedback welcome but will probably break your build.
@@ -37,10 +37,10 @@ Use [GraalVM](https://graalvm.org) from [Bazel](https://bazel.build), with suppo
 ```python
 http_archive(
     name = "rules_graalvm",
-    sha256 = "157efdd3a6ac12b85838ae81042f2fdcf60d70ba5fb279585ca8f27cf7f1a94d",
-    strip_prefix = "rules_graalvm-0.10.0",
+    sha256 = "ca6fa64992139a3fd04fd878857319d4b865c80624e6a73967d340be4f64cb52",
+    strip_prefix = "rules_graalvm-0.10.1",
     urls = [
-        "https://github.com/sgammon/rules_graalvm/releases/download/v0.10.0/rules_graalvm-0.10.0.zip",
+        "https://github.com/sgammon/rules_graalvm/releases/download/v0.10.1/rules_graalvm-0.10.1.zip",
     ],
 )
 ```
@@ -72,16 +72,16 @@ graalvm_repository(
 **Or, via `MODULE.bazel`:**
 
 ```python
-bazel_dep(name = "rules_graalvm", version = "0.10.0")
+bazel_dep(name = "rules_graalvm", version = "0.10.1")
 ```
 
 ```python
 # Until we ship to BCR:
 archive_override(
     module_name = "rules_graalvm",
-    urls = ["https://github.com/sgammon/rules_graalvm/releases/download/v0.10.0/rules_graalvm-0.10.0.zip"],
-    strip_prefix = "rules_graalvm-0.10.0",
-    integrity = "sha256-FX7906asErhYOK6BBC8v3PYNcLpfsnlYXKjyfPfxqU0=",
+    urls = ["https://github.com/sgammon/rules_graalvm/releases/download/v0.10.1/rules_graalvm-0.10.1.zip"],
+    strip_prefix = "rules_graalvm-0.10.1",
+    integrity = "sha256-ym+mSZITmj/QT9h4hXMZ1LhlyAYk5qc5Z9NAvk9ky1I=",
 )
 ```
 


### PR DESCRIPTION
## Summary

Fix release for `0.10.0`, which is sadly DOA due to a horrible BCR accident in the workplace. Addresses issues which surfaced in bazelbuild/bazel-central-registry#836.

## Changelog

- fix: bcr publish gone wrong
- chore: bump version → `0.10.1`
- chore: issue new tarballs
- chore: update readme/doc index