### PR TITLE
fix: remove `module_ctx.extension_metadata`

### DIFF
--- a/extensions.bzl
+++ b/extensions.bzl
@@ -32,18 +32,6 @@ def _gvm_impl(mctx):
         setup_actions = selected.setup_actions,
     )
 
-    _extension_meta = {}
-    if not mctx.root_module_has_non_dev_dependency:
-        _extension_meta["root_module_direct_dev_deps"] = [selected.name]
-        _extension_meta["root_module_direct_deps"] = []
-    else:
-        _extension_meta["root_module_direct_deps"] = [selected.name]
-        _extension_meta["root_module_direct_dev_deps"] = []
-
-    return mctx.extension_metadata(
-        **_extension_meta
-    )
-
 _graalvm = tag_class(attrs = {
     "name": attr.string(mandatory = True),
     "version": attr.string(mandatory = True),


### PR DESCRIPTION
In the current Bzlmod setup, all repositories generated by the `graalvm` extension may or may not be used by users and whether they should be can't be predicted based on the given tags: Users that want to generate toolchains need the `<name>_toolchains` repo, users that rely on SDK files need the `<name>` repo.

For now, remove the use of `module_ctx.extension_metadata` so that no warning is shown when users register toolchains in `<name>_toolchains`. In the future, we should improve the way toolchains are registered with Bzlmod by automatically registering a toolchain configured via tags.