### PR TITLE
fix(windows): added `use_param_file` for args

### DIFF
--- a/internal/native_image/rules.bzl
+++ b/internal/native_image/rules.bzl
@@ -81,7 +81,7 @@ def _graal_binary_implementation(ctx):
         ),
     )
 
-    args = ctx.actions.args()
+    args = ctx.actions.args().use_param_file("@%s", use_always=False)
     binary = _prepare_native_image_rule_context(
         ctx,
         args,


### PR DESCRIPTION
> From original PR:

Hey, firstly thanks for making this project.

I am using it on windows and was running into an issue where the command used to invoke native-image was too long for windows. It turns out graalvm added support for args files here https://github.com/graalvm/native-build-tools/pull/205 and it wasn't too hard to add support for them here.

Thanks
Ruairidh

cc / @ruwi-next