### PR TITLE
fix: update skylib to fix Bazel version check for dev builds instead

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,7 +40,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "bazel_skylib",
-    version = "1.4.2",
+    version = "1.5.0",
 )
 bazel_dep(
     name = "apple_support",

--- a/internal/deps.bzl
+++ b/internal/deps.bzl
@@ -39,10 +39,10 @@ def rules_graalvm_repositories(
         maybe(
             name = "bazel_skylib",
             repo_rule = http_archive,
-            sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+            sha256 = "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
-                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
             ],
         )
 

--- a/internal/graalvm_bindist.bzl
+++ b/internal/graalvm_bindist.bzl
@@ -44,12 +44,6 @@ _NONLEGACY_X86_TAG = "x64"
 _LEGACY_DARWIN_TAG = "darwin"
 _NONLEGACY_DARWIN_TAG = "macos"
 
-def _get_bazel_version():
-    # Development versions of Bazel return an empty version string, but such a
-    # string isn't accepted by versions.is_at_least. We use a fake version that
-    # is certain to be higher than all released versions of Bazel.
-    return versions.get() or "9999.0.0"
-
 def _get_artifact_info(ctx, dist, platform, version, component = None, strict = True):
     info = resolve_distribution_artifact(dist, platform, version, component, strict)
     if info == None:
@@ -76,7 +70,7 @@ def _get_platform(ctx, newdist):
 
     # fix: before bazel5, the `arch` property did not exist on `repository_os`, so we need
     # to do without it and simply assume `amd64`.
-    if not newdist or not versions.is_at_least("5", _get_bazel_version()):
+    if not newdist or not versions.is_at_least("5", versions.get()):
         return _get_platform_legacy(ctx, not newdist)
     elif ctx.os.name == "linux":
         return ("linux-%s" % (arch_labels[ctx.os.arch] or ctx.os.arch), "linux", "tar.gz")
@@ -465,13 +459,13 @@ alias(
 
     # if we're running on Bazel before 7, we need to omit the bootstrap toolchain, because
     # it doesn't yet exist in Bazel's internals.
-    if not versions.is_at_least("7", _get_bazel_version()):
+    if not versions.is_at_least("7", versions.get()):
         bootstrap_toolchain_alias = ""
 
     # bazel 6+ has support for the `version` attribute on the `java_runtime` rule. earlier
     # versions do not, so we omit it.
     toolchain_template = _JDK_BUILD_TEMPLATE
-    if not versions.is_at_least("6", _get_bazel_version()):
+    if not versions.is_at_least("6", versions.get()):
         toolchain_template = _JDK_BUILD_TEMPLATE_BAZEL5
 
     toolchain_aliases_template = """
@@ -736,7 +730,7 @@ def graalvm_repository(
     # if we're running on Bazel before 7, we need to omit the bootstrap toolchain, because
     # it doesn't yet exist in Bazel's internals.
     bootstrap_runtime_toolchain = ""
-    if versions.is_at_least("7", _get_bazel_version()):
+    if versions.is_at_least("7", versions.get()):
         bootstrap_runtime_toolchain = """
 toolchain(
     name = "bootstrap_runtime_toolchain",


### PR DESCRIPTION
This reverts commit 3b204f7ee3e756e477d0cb77cae04d89c457cd7d and instead resolves the problem by updating skylib.