### PR TITLE
docs: Remove outdated reference to archive_override

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,6 @@ register_graalvm_toolchains()
 
 **Or, via `MODULE.bazel`:**
 
-> [!IMPORTANT]  
-> To use Bzlmod with `rules_graalvm`, you will need the `archive_override` below (until we go live on BCR).
-
 ```starlark
 bazel_dep(name = "rules_graalvm", version = "0.10.3")
 ```


### PR DESCRIPTION
As there is no "`archive_override` below" (anymore, presumably).

https://registry.bazel.build/modules/rules_graalvm seems to be live, so "until we go live on BCR" appears outdated.