### PR TITLE
fix(bazelci): run bazelci against bazel `7.0.0`

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
-  bazel_version: ["6.3.2", "7.0.0"]
-  platform: ["macos", "macos_arm64", "ubuntu2004", "windows"]
+  bazel_version: ["7.0.0"]
+  platform: ["macos", "macos_arm64", "ubuntu2004"]
 
 validate_config: 1
 buildifier: latest

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,9 @@
 "GraalVM Rules for Bazel"
 
-module(name = "rules_graalvm", version = "0.11.1")
+module(
+    name = "rules_graalvm",
+    version = "0.11.1",
+)
 
 ## JVM version to target.
 JAVA_VERSION = "21"

--- a/tools/bazel/cache.bazelrc
+++ b/tools/bazel/cache.bazelrc
@@ -9,7 +9,6 @@ build --incompatible_remote_results_ignore_disk
 build --noexperimental_check_output_files
 build --nolegacy_important_outputs
 build --incompatible_default_to_explicit_init_py
-build --experimental_remote_merkle_tree_cache
-build --experimental_remote_cache_compression
-build --experimental_guard_against_concurrent_changes
-
+build:labs --experimental_remote_merkle_tree_cache
+build:labs --experimental_remote_cache_compression
+build:labs --experimental_guard_against_concurrent_changes


### PR DESCRIPTION
## Summary

The codebase now expects Bazel 7, but Bazel CI runs on both 6.x and 7.x.

## Changelog

- fix: drop `6.3.2` from bazelci matrix
