### PR TITLE
fix(ci): dependency review needs the graph

### DIFF
--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -44,6 +44,7 @@ jobs:
   dependency-review:
     name: "Dependency Review"
     runs-on: ubuntu-latest
+    needs: [dependency-graph]
     permissions:
       contents: read
       pull-requests: write
@@ -55,10 +56,12 @@ jobs:
       - name: "Checkout Repository"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: "Dependency Review"
-        uses: actions/dependency-review-action@4901385134134e04cec5fbe5ddfe3b2c5bd5d976 # v4.0.0
+        uses: actions/dependency-review-action@9129d7d40b8c12c1ed0f60400d00c92d437adcce # v4.1.3
         with:
           config-file: "./.github/dependency-review-config.yml"
           comment-summary-in-pr: always
+          retry-on-snapshot-warnings: true
+          warn-only: true
 
   test:
     name: "Tests: ${{ matrix.label }}"


### PR DESCRIPTION
## Summary

For Dependency Review to work properly, one must first publish a Dependency Graph.

## Changelog

- fix: wait for dependency graph to run review
- fix: retry on snapshot warnings for dependency review