### PR TITLE
fix: support macos minimum version

### DIFF
--- a/internal/native_image/rules.bzl
+++ b/internal/native_image/rules.bzl
@@ -143,10 +143,13 @@ def _graal_binary_implementation(ctx):
         # https://github.com/oracle/graal/blob/77a7f6a691024d22367ae33be4da0c15ceb6a246/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java#L1801-L1808
         xcode_args.add(apple_support.path_placeholders.xcode(), format = "-EDEVELOPER_DIR=%s")
         xcode_args.add(apple_support.path_placeholders.sdkroot(), format = "-ESDKROOT=%s")
+        xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+        # native-image reads the MACOSX_DEPLOYMENT_TARGET env var to determine target macos version
+        run_params["env"]["MACOSX_DEPLOYMENT_TARGET"] = str(xcode_config.minimum_os_for_platform_type(apple_common.platform_type.macos))
         apple_support.run(
             actions = graal_actions,
             apple_fragment = ctx.fragments.apple,
-            xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+            xcode_config = xcode_config,
             xcode_path_resolve_level = apple_support.xcode_path_resolve_level.args,
             arguments = [args, xcode_args],
             **run_params


### PR DESCRIPTION
Hi,

# Summary
When building for macOS it is often required to set `--macos_minimum_os` to specify the minimum os version to build for. Running a binary on an os built for a later os could mean it could crash when trying to resolve symbols not in this os release. Not setting this will default to the build machine's os version.

Using this with rules_graalvm does not work as you can see when setting `--macos_minimum_os=11.0` and running `otool -l ./bin | grep -B1 -A3 MIN_MAC`.

The solution is to set env var `MACOSX_DEPLOYMENT_TARGET` for xcode to pick up as documented here https://github.com/clj-easy/graal-docs?tab=readme-ov-file#targeting-a-minimum-macos-version

Thanks