### PR TITLE
fix: add data files to inputs

### DIFF
--- a/internal/native_image/classic.bzl
+++ b/internal/native_image/classic.bzl
@@ -58,6 +58,9 @@ def _graal_binary_classic_implementation(ctx):
         native_toolchain.c_compiler_path,
     )
 
+    if ctx.files.data:
+      direct_inputs.extend(ctx.files.data)
+
     inputs = depset(
         direct_inputs,
         transitive = transitive_inputs,

--- a/internal/native_image/rules.bzl
+++ b/internal/native_image/rules.bzl
@@ -113,6 +113,9 @@ def _graal_binary_implementation(ctx):
         bin_postfix = bin_postfix,
     )
 
+    if ctx.files.data:
+      direct_inputs.extend(ctx.files.data)
+
     # assemble final inputs
     inputs = depset(
         direct_inputs,


### PR DESCRIPTION
Fixed a bug where data files weren't provided to `inputs`.