### PR TITLE
fix: scorecards attributes with workflows

### DIFF
--- a/.gitattributes-release
+++ b/.gitattributes-release
@@ -6,6 +6,7 @@ local.bazelrc.inert export-ignore
 .aspect/bazelrc/ export-ignore
 .bazelci/ export-ignore
 .bcr/ export-ignore
+.github/ export-ignore
 .husky/ export-ignore
 docs/ export-ignore
 tools/ export-ignore

--- a/.github/workflows/deploy.docs.yml
+++ b/.github/workflows/deploy.docs.yml
@@ -12,9 +12,6 @@ name: Docs
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
-  deployments: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -27,6 +24,11 @@ jobs:
     name: "Build: Docs"
     continue-on-error: true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      deployments: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2


### PR DESCRIPTION
- ossf/scorecard#2489

Includes GitHub workflows in our tarball export, so that Scorecards' scanner action can see them. Creates a `.gitattributes-release` which can be swapped in during releases. Maybe this `.gitattributes` file can be active only for release commits/tags/branches, I'm not sure yet. In the meantime it can document what the attributes were before remediating this bug.

Also fixes some permission isolation for workflows, which should also improve our score now that the workflows will be visible.