### PR TITLE
Allow getting output shared libraries

### DIFF
--- a/internal/native_image/builder.bzl
+++ b/internal/native_image/builder.bzl
@@ -168,7 +168,8 @@ def _configure_native_test_flags(ctx, args):
 def assemble_native_build_options(
         ctx,
         args,
-        binary,
+        binary_name,
+        outdir,
         classpath_depset,
         direct_inputs,
         c_compiler_path,
@@ -204,13 +205,13 @@ def assemble_native_build_options(
     if not ctx.attr.allow_fallback:
         args.add("--no-fallback")
 
-    trimmed_basename = binary.basename
+    trimmed_binary_name = binary_name
     if bin_postfix:
-        trimmed_basename = trimmed_basename[0:-(len(bin_postfix))]
+        trimmed_binary_name = trimmed_binary_name[0:-(len(bin_postfix))]
 
     args.add(ctx.attr.main_class, format = "-H:Class=%s")
-    args.add(trimmed_basename, format = "-H:Name=%s")
-    args.add(binary.dirname, format = "-H:Path=%s")
+    args.add(trimmed_binary_name, format = "-H:Name=%s")
+    args.add(outdir, format = "-H:Path=%s")
     args.add("-H:+ReportExceptionStackTraces")
 
     if not ctx.attr.check_toolchains:

--- a/internal/native_image/classic.bzl
+++ b/internal/native_image/classic.bzl
@@ -1,6 +1,10 @@
 "Legacy ('classic') rules for building with GraalVM on Bazel."
 
 load(
+    "//internal/native_image:builder.bzl",
+    _assemble_native_build_options = "assemble_native_build_options",
+)
+load(
     "//internal/native_image:common.bzl",
     _BAZEL_CPP_TOOLCHAIN_TYPE = "BAZEL_CPP_TOOLCHAIN_TYPE",
     _BAZEL_CURRENT_CPP_TOOLCHAIN = "BAZEL_CURRENT_CPP_TOOLCHAIN",
@@ -10,7 +14,7 @@ load(
     _NATIVE_IMAGE_ATTRS = "NATIVE_IMAGE_ATTRS",
     _OPTIMIZATION_MODE_CONDITION = "OPTIMIZATION_MODE_CONDITION",
     _RULES_REPO = "RULES_REPO",
-    _prepare_native_image_rule_context = "prepare_native_image_rule_context",
+    _path_list_separator = "path_list_separator",
 )
 load(
     "//internal/native_image:toolchain.bzl",
@@ -50,12 +54,20 @@ def _graal_binary_classic_implementation(ctx):
     )
 
     args = ctx.actions.args()
-    binary = _prepare_native_image_rule_context(
+
+    binary_name = ctx.attr.executable_name.replace("%target%", ctx.attr.name)
+    binary = ctx.actions.declare_file("output/" + binary_name)
+    path_list_separator = _path_list_separator(ctx)
+
+    _assemble_native_build_options(
         ctx,
         args,
+        binary_name,
+        binary.dirname,
         classpath_depset,
         direct_inputs,
         native_toolchain.c_compiler_path,
+        path_list_separator,
     )
 
     if ctx.files.data:


### PR DESCRIPTION
Hi

Native image can output shared libraries along with the native native binary. These are placed in the output directory next to the binary executable, but I could not find a way of collecting these files. 

I wanted to be able to detect the files that native image would output and declare those as outputs but I wasn't able to figure out that. It seems that the libraries that are produced are determined by the code written and so we cannot determine this just by inspecting the command we are invoking.

Instead I exposed an attr so the user can specify the extra files they expect to be generated. This is probably not ideal but it works for my use case.

Any feedback is appreciated.