### PR TITLE
chore: Switch to `.tar.gz` release archives

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_graalvm-{VERSION}.tgz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_graalvm-{VERSION}.tar.gz"
 }

--- a/.github/workflows/on.release.yml
+++ b/.github/workflows/on.release.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Release: GitHub"
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
     with:
-      release_files: rules_graalvm-*.tgz
+      release_files: rules_graalvm-*.tar.gz
       prerelease: false
       tag_name: ${{ inputs.tag_name || github.ref_name }}
 

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -7,7 +7,7 @@ set -o errexit -o nounset -o pipefail
 TAG=${GITHUB_REF_NAME}
 # The prefix is chosen to match what GitHub generates for source archives
 PREFIX="rules_graalvm-${TAG:1}"
-ARCHIVE="rules_graalvm-${TAG:1}.tgz"
+ARCHIVE="rules_graalvm-${TAG:1}.tar.gz"
 git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 


### PR DESCRIPTION
publish-to-bcr doesn't support `.tgz` yet.