### PR TITLE
fix: stop excluding `example/` from release archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,7 +23,6 @@ go.mod export-ignore
 go.sum export-ignore
 Makefile export-ignore
 package.json export-ignore
-example/ export-ignore
 version.bazelrc export-ignore
 maven_install.json linguist-generated=true
 internal/graalvm_bindist_map.bzl linguist-generated=true

--- a/.gitattributes-release
+++ b/.gitattributes-release
@@ -24,7 +24,6 @@ go.mod export-ignore
 go.sum export-ignore
 Makefile export-ignore
 package.json export-ignore
-example/ export-ignore
 version.bazelrc export-ignore
 maven_install.json linguist-generated=true
 internal/graalvm_bindist_map.bzl linguist-generated=true


### PR DESCRIPTION
The BCR presubmit builds the test module at `example/integration_tests/bzlmod` from within the release archive, but `example/ export-ignore` in `.gitattributes` makes `git archive` drop the directory from the archive, so every presubmit job fails immediately with a missing module path.

This has broken BCR publication for every release since the line was introduced in the 0.11.2 release commit — which is also why 0.11.2 never landed in the BCR (its versions stop at 0.11.1) and why all presubmit checks on bazelbuild/bazel-central-registry#9753 (0.12.0) fail.